### PR TITLE
Add deposit-withdraw GET endpoint

### DIFF
--- a/huobi/rest/endpoints/common.py
+++ b/huobi/rest/endpoints/common.py
@@ -26,3 +26,23 @@ class HuobiRestClientCommon(HuobiRestClientBase):
         path='/v1/common/timestamp',
         auth_required=False,
     )
+
+    deposit_withdraw = Endpoint(
+        method='GET',
+        path='/v1/query/deposit-withdraw',
+        params={
+            'currency': {
+                'required': True
+            },
+            'type': {
+                'required': True,
+                'choices': ['deposit', 'withdraw']
+            },
+            'from': {
+                'default': 0,
+            },
+            'size': {
+                'default': 100,
+            }
+        }
+    )


### PR DESCRIPTION
This PR adds https://github.com/huobiapi/API_Docs_en/wiki/REST_Reference#get-v1querydeposit-withdraw---get-deposit-or-withdraw-records

Happy to move into its own `query` endpoint and/or clean it up, if this is useful.